### PR TITLE
refactor: separate business logic from CLI

### DIFF
--- a/src/deck/cli.py
+++ b/src/deck/cli.py
@@ -1,34 +1,16 @@
 from __future__ import annotations
-import json
-from pathlib import Path
+
 from typing import Optional
 
 import typer
-from rich.table import Table
-from rich import box
 
-from .logging import get_console, setup_logging
-from .state import State
-from .config import load_service_spec, list_services
-from .providers.deploy import ComposeDeployer, DeployOptions
-from .providers.backup import ResticBackup
-from .providers.targets import load_inventory, check_target, endpoint_for
+from .context import Ctx
+from .logging import setup_logging
+from . import commands
 
-app = typer.Typer(add_completion=False, help="Deploy, backup and migrate containerized services")
-
-
-class Ctx:
-    def __init__(self, config: str, state: str, json_out: bool, apply: bool):
-        self.config = config
-        self.state = state
-        self.json_out = json_out
-        self.apply = apply
-        self.console = get_console()
-        self.store = State(state)
-        self.store.open()
-
-    def close(self):
-        self.store.close()
+app = typer.Typer(
+    add_completion=False, help="Deploy, backup and migrate containerized services"
+)
 
 
 @app.callback()
@@ -37,8 +19,10 @@ def main(
     config: str = typer.Option("./deck.yaml", help="Path to global config file"),
     state: str = typer.Option("./state.db", help="Path to state database (sqlite)"),
     json_out: bool = typer.Option(False, "--json", help="JSON output where supported"),
-    apply: bool = typer.Option(False, "--apply", help="Execute actions (otherwise dry-run)"),
-):
+    apply: bool = typer.Option(
+        False, "--apply", help="Execute actions (otherwise dry-run)"
+    ),
+) -> None:
     """Global options & setup."""
     setup_logging()
     ctx.obj = Ctx(config, state, json_out, apply)
@@ -47,36 +31,12 @@ def main(
 @app.command()
 def status(
     ctx: typer.Context,
-    service: Optional[str] = typer.Argument(None, help="Service name or omit to list all"),
-):
-    """Show service or fleet status (skeleton)."""
-    c: Ctx = ctx.obj
-    if not service:
-        names = list_services()
-        if c.json_out:
-            typer.echo(json.dumps({"services": names}))
-            return
-        table = Table(title="Services", box=box.SIMPLE)
-        table.add_column("Name", style="bold")
-        for n in names:
-            table.add_row(n)
-        c.console.print(table)
-        return
-
-    sp = load_service_spec(service)
-    out = {
-        "service": sp.metadata.name,
-        "desiredTarget": sp.spec.deployment.target,
-        "method": sp.spec.deployment.method,
-        "healthy": None,
-    }
-    if c.json_out:
-        typer.echo(json.dumps(out, indent=2))
-    else:
-        c.console.print(f"[bold]Service[/]: {out['service']}")
-        c.console.print(f"Target:  {out['desiredTarget']}")
-        c.console.print(f"Method:  {out['method']}")
-        c.console.print("Healthy: unknown")
+    service: Optional[str] = typer.Argument(
+        None, help="Service name or omit to list all"
+    ),
+) -> None:
+    """Show service or fleet status."""
+    commands.status(ctx.obj, service)
 
 
 @app.command()
@@ -85,27 +45,12 @@ def deploy(
     service: str = typer.Argument(..., help="Service name"),
     target: Optional[str] = typer.Option(None, help="Override destination target"),
     timeout: int = typer.Option(600, help="Wait timeout in seconds"),
-    force: bool = typer.Option(False, help="Force redeploy even if no changes detected"),
-):
-    """Deploy or update a service to its target (skeleton)."""
-    c: Ctx = ctx.obj
-    sp = load_service_spec(service)
-    tgt = target or sp.spec.deployment.target
-
-    plan = ""
-    if sp.spec.deployment.method == "compose":
-        cp = sp.compose_path
-        plan = ComposeDeployer(sp.metadata.name, str(cp), tgt, DeployOptions(timeout, force)).plan()
-    else:
-        plan = f"Would deploy {sp.metadata.name} via {sp.spec.deployment.method} to {tgt}"
-
-    mode = "apply" if c.apply else "plan"
-    c.console.print(f"[{mode}] {plan}")
-    c.store.event(service=sp.metadata.name, command="deploy", mode=mode, payload={"target": tgt})
-
-    if c.apply:
-        # TODO: call real provider .apply()
-        pass
+    force: bool = typer.Option(
+        False, help="Force redeploy even if no changes detected"
+    ),
+) -> None:
+    """Deploy or update a service to its target."""
+    commands.deploy(ctx.obj, service, target, timeout, force)
 
 
 @app.command()
@@ -116,16 +61,9 @@ def backup(
     verify: bool = typer.Option(False, help="Verify repository integrity"),
     list_: bool = typer.Option(False, "--list", help="List snapshots/archives"),
     prune: bool = typer.Option(False, help="Prune old snapshots per retention"),
-):
-    """Run or manage backups for a service (skeleton)."""
-    c: Ctx = ctx.obj
-    sp = load_service_spec(service)
-    b = ResticBackup(service=sp.metadata.name, repo=sp.spec.storage.backup.repository)
-
-    mode = "apply" if c.apply else "plan"
-    c.console.print(f"[{mode}] backup {sp.metadata.name} (now={now} verify={verify} list={list_} prune={prune}) via {sp.spec.storage.backup.driver}")
-    c.console.print(b.plan())
-    c.store.event(service=sp.metadata.name, command="backup", mode=mode, payload={"now": now, "verify": verify, "list": list_, "prune": prune})
+) -> None:
+    """Run or manage backups for a service."""
+    commands.backup(ctx.obj, service, now, verify, list_, prune)
 
 
 @app.command()
@@ -134,100 +72,43 @@ def migrate(
     service: str = typer.Argument(..., help="Service name"),
     to: str = typer.Option(..., "--to", help="Destination target name"),
     via: str = typer.Option("auto", help="Strategy: auto|rsync|restic|snapshot"),
-    downtime_seconds: int = typer.Option(30, help="Expected downtime window during cutover"),
-):
-    """Migrate a service's data & workload to another target (skeleton)."""
-    c: Ctx = ctx.obj
-    sp = load_service_spec(service)
-    mode = "apply" if c.apply else "plan"
-    msg = f"[{mode}] would migrate {sp.metadata.name} from {sp.spec.deployment.target} to {to} via {via} (downtime≈{downtime_seconds}s)"
-    c.console.print(msg)
-    c.store.event(service=sp.metadata.name, command="migrate", mode=mode, payload={"to": to, "via": via, "downtime": downtime_seconds})
+    downtime_seconds: int = typer.Option(
+        30, help="Expected downtime window during cutover"
+    ),
+) -> None:
+    """Migrate a service's data & workload to another target."""
+    commands.migrate(ctx.obj, service, to, via, downtime_seconds)
 
 
 @app.command()
-def start(ctx: typer.Context, service: str = typer.Argument(..., help="Service name")):
-    """Start (resume) a service (skeleton)."""
-    c: Ctx = ctx.obj
-    sp = load_service_spec(service)
-    mode = "apply" if c.apply else "plan"
-    c.console.print(f"[{mode}] would start {sp.metadata.name} via {sp.spec.deployment.method}")
-    c.store.event(service=sp.metadata.name, command="start", mode=mode, payload={})
+def start(
+    ctx: typer.Context,
+    service: str = typer.Argument(..., help="Service name"),
+) -> None:
+    """Start (resume) a service."""
+    commands.start(ctx.obj, service)
 
 
 @app.command()
-def stop(ctx: typer.Context, service: str = typer.Argument(..., help="Service name")):
-    """Stop (quiesce) a service (skeleton)."""
-    c: Ctx = ctx.obj
-    sp = load_service_spec(service)
-    mode = "apply" if c.apply else "plan"
-    c.console.print(f"[{mode}] would stop {sp.metadata.name} via {sp.spec.deployment.method}")
-    c.store.event(service=sp.metadata.name, command="stop", mode=mode, payload={})
+def stop(
+    ctx: typer.Context,
+    service: str = typer.Argument(..., help="Service name"),
+) -> None:
+    """Stop (quiesce) a service."""
+    commands.stop(ctx.obj, service)
 
 
 @app.command("targets")
 def list_targets(
     ctx: typer.Context,
-    check: bool = typer.Option(False, "--check", help="Probe each target for reachability"),
-    inventory: Optional[str] = typer.Option(None, "--inventory", help="Path to targets/inventory.yaml (defaults to ./targets/inventory.yaml)"),
-):
+    check: bool = typer.Option(
+        False, "--check", help="Probe each target for reachability"
+    ),
+    inventory: Optional[str] = typer.Option(
+        None,
+        "--inventory",
+        help="Path to targets/inventory.yaml (defaults to ./targets/inventory.yaml)",
+    ),
+) -> None:
     """List all targets; optionally check connectivity."""
-    c: Ctx = ctx.obj
-    inv_path = Path(inventory) if inventory else None
-    targets = load_inventory(inv_path)
-
-    if c.json_out:
-        if check:
-            results = []
-            for t in targets:
-                r = check_target(t)
-                results.append(
-                    {
-                        "name": r.name,
-                        "type": r.type,
-                        "endpoint": r.endpoint,
-                        "reachable": r.reachable,
-                        "latency_ms": r.latency_ms,
-                        "detail": r.detail,
-                    }
-                )
-            typer.echo(json.dumps({"targets": results}, indent=2))
-        else:
-            typer.echo(
-                json.dumps(
-                    {
-                        "targets": [
-                            {"name": t.name, "type": t.type, "endpoint": endpoint_for(t)} for t in targets
-                        ]
-                    },
-                    indent=2,
-                )
-            )
-        return
-
-    title = "Targets (checked)" if check else "Targets"
-    table = Table(title=title, box=box.SIMPLE)
-    table.add_column("Name", style="bold")
-    table.add_column("Type")
-    table.add_column("Endpoint")
-    if check:
-        table.add_column("Reachable")
-        table.add_column("Latency ms")
-        table.add_column("Detail")
-
-    for t in targets:
-        ep = endpoint_for(t)
-        if check:
-            r = check_target(t)
-            table.add_row(
-                r.name,
-                r.type,
-                r.endpoint,
-                "✅" if r.reachable else "❌",
-                f"{r.latency_ms:.1f}" if r.latency_ms is not None else "-",
-                r.detail,
-            )
-        else:
-            table.add_row(t.name, t.type, ep)
-
-    c.console.print(table)
+    commands.list_targets(ctx.obj, check, inventory)

--- a/src/deck/commands.py
+++ b/src/deck/commands.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from rich import box
+from rich.table import Table
+
+from .context import Ctx
+from .config import load_service_spec, list_services
+from .providers.backup import ResticBackup
+from .providers.deploy import ComposeDeployer, DeployOptions
+from .providers.targets import check_target, endpoint_for, load_inventory
+
+
+def status(c: Ctx, service: Optional[str]) -> None:
+    """Show service or fleet status."""
+    if not service:
+        names = list_services()
+        if c.json_out:
+            print(json.dumps({"services": names}))
+            return
+        table = Table(title="Services", box=box.SIMPLE)
+        table.add_column("Name", style="bold")
+        for n in names:
+            table.add_row(n)
+        c.console.print(table)
+        return
+
+    sp = load_service_spec(service)
+    out = {
+        "service": sp.metadata.name,
+        "desiredTarget": sp.spec.deployment.target,
+        "method": sp.spec.deployment.method,
+        "healthy": None,
+    }
+    if c.json_out:
+        print(json.dumps(out, indent=2))
+    else:
+        c.console.print(f"[bold]Service[/]: {out['service']}")
+        c.console.print(f"Target:  {out['desiredTarget']}")
+        c.console.print(f"Method:  {out['method']}")
+        c.console.print("Healthy: unknown")
+
+
+def deploy(
+    c: Ctx, service: str, target: Optional[str], timeout: int, force: bool
+) -> None:
+    """Deploy or update a service to its target."""
+    sp = load_service_spec(service)
+    tgt = target or sp.spec.deployment.target
+
+    if sp.spec.deployment.method == "compose":
+        cp = sp.compose_path
+        plan = ComposeDeployer(
+            sp.metadata.name, str(cp), tgt, DeployOptions(timeout, force)
+        ).plan()
+    else:
+        plan = (
+            f"Would deploy {sp.metadata.name} via {sp.spec.deployment.method} to {tgt}"
+        )
+
+    mode = "apply" if c.apply else "plan"
+    c.console.print(f"[{mode}] {plan}")
+    c.store.event(
+        service=sp.metadata.name, command="deploy", mode=mode, payload={"target": tgt}
+    )
+
+    if c.apply:
+        # TODO: call real provider .apply()
+        pass
+
+
+def backup(
+    c: Ctx,
+    service: str,
+    now: bool,
+    verify: bool,
+    list_: bool,
+    prune: bool,
+) -> None:
+    """Run or manage backups for a service."""
+    sp = load_service_spec(service)
+    b = ResticBackup(service=sp.metadata.name, repo=sp.spec.storage.backup.repository)
+
+    mode = "apply" if c.apply else "plan"
+    c.console.print(
+        f"[{mode}] backup {sp.metadata.name} (now={now} verify={verify} list={list_} prune={prune}) "
+        f"via {sp.spec.storage.backup.driver}"
+    )
+    c.console.print(b.plan())
+    c.store.event(
+        service=sp.metadata.name,
+        command="backup",
+        mode=mode,
+        payload={"now": now, "verify": verify, "list": list_, "prune": prune},
+    )
+
+
+def migrate(
+    c: Ctx,
+    service: str,
+    to: str,
+    via: str,
+    downtime_seconds: int,
+) -> None:
+    """Migrate a service's data & workload to another target."""
+    sp = load_service_spec(service)
+    mode = "apply" if c.apply else "plan"
+    msg = (
+        f"[{mode}] would migrate {sp.metadata.name} from {sp.spec.deployment.target} "
+        f"to {to} via {via} (downtime≈{downtime_seconds}s)"
+    )
+    c.console.print(msg)
+    c.store.event(
+        service=sp.metadata.name,
+        command="migrate",
+        mode=mode,
+        payload={"to": to, "via": via, "downtime": downtime_seconds},
+    )
+
+
+def start(c: Ctx, service: str) -> None:
+    """Start (resume) a service."""
+    sp = load_service_spec(service)
+    mode = "apply" if c.apply else "plan"
+    c.console.print(
+        f"[{mode}] would start {sp.metadata.name} via {sp.spec.deployment.method}"
+    )
+    c.store.event(service=sp.metadata.name, command="start", mode=mode, payload={})
+
+
+def stop(c: Ctx, service: str) -> None:
+    """Stop (quiesce) a service."""
+    sp = load_service_spec(service)
+    mode = "apply" if c.apply else "plan"
+    c.console.print(
+        f"[{mode}] would stop {sp.metadata.name} via {sp.spec.deployment.method}"
+    )
+    c.store.event(service=sp.metadata.name, command="stop", mode=mode, payload={})
+
+
+def list_targets(c: Ctx, check: bool, inventory: Optional[str]) -> None:
+    """List all targets; optionally check connectivity."""
+    inv_path = Path(inventory) if inventory else None
+    targets = load_inventory(inv_path)
+
+    if c.json_out:
+        if check:
+            results = []
+            for t in targets:
+                r = check_target(t)
+                results.append(
+                    {
+                        "name": r.name,
+                        "type": r.type,
+                        "endpoint": r.endpoint,
+                        "reachable": r.reachable,
+                        "latency_ms": r.latency_ms,
+                        "detail": r.detail,
+                    }
+                )
+            print(json.dumps({"targets": results}, indent=2))
+        else:
+            print(
+                json.dumps(
+                    {
+                        "targets": [
+                            {
+                                "name": t.name,
+                                "type": t.type,
+                                "endpoint": endpoint_for(t),
+                            }
+                            for t in targets
+                        ]
+                    },
+                    indent=2,
+                )
+            )
+        return
+
+    title = "Targets (checked)" if check else "Targets"
+    table = Table(title=title, box=box.SIMPLE)
+    table.add_column("Name", style="bold")
+    table.add_column("Type")
+    table.add_column("Endpoint")
+    if check:
+        table.add_column("Reachable")
+        table.add_column("Latency ms")
+        table.add_column("Detail")
+
+    for t in targets:
+        ep = endpoint_for(t)
+        if check:
+            r = check_target(t)
+            table.add_row(
+                r.name,
+                r.type,
+                r.endpoint,
+                "✅" if r.reachable else "❌",
+                f"{r.latency_ms:.1f}" if r.latency_ms is not None else "-",
+                r.detail,
+            )
+        else:
+            table.add_row(t.name, t.type, ep)
+
+    c.console.print(table)

--- a/src/deck/context.py
+++ b/src/deck/context.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from .logging import get_console
+from .state import State
+
+
+class Ctx:
+    def __init__(self, config: str, state: str, json_out: bool, apply: bool):
+        self.config = config
+        self.state = state
+        self.json_out = json_out
+        self.apply = apply
+        self.console = get_console()
+        self.store = State(state)
+        self.store.open()
+
+    def close(self) -> None:
+        self.store.close()


### PR DESCRIPTION
## Summary
- move stateful CLI context into a dedicated module
- extract service operations into `commands` module
- make `cli` commands thin wrappers around business logic

## Testing
- `ruff check src/deck/cli.py src/deck/commands.py src/deck/context.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7cc4275ac8329b3c292af13124c0c